### PR TITLE
Set up locomanipulation environment

### DIFF
--- a/source/isaaclab_assets/isaaclab_assets/robots/kscale.py
+++ b/source/isaaclab_assets/isaaclab_assets/robots/kscale.py
@@ -237,3 +237,29 @@ KBOT_CFG = ArticulationCfg(
     soft_joint_pos_limit_factor=1.0,
     actuators=_ACTUATORS,
 )
+
+ARM_JOINT_NAMES = [
+    "dof_right_shoulder_pitch_03",
+    "dof_right_shoulder_roll_03",
+    "dof_right_shoulder_yaw_02",
+    "dof_right_elbow_02",
+    "dof_right_wrist_00",
+    "dof_left_shoulder_pitch_03",
+    "dof_left_shoulder_roll_03",
+    "dof_left_shoulder_yaw_02",
+    "dof_left_elbow_02",
+    "dof_left_wrist_00"
+]
+
+LEG_JOINT_NAMES = [
+    "dof_right_hip_pitch_04",
+    "dof_right_hip_roll_03",
+    "dof_right_hip_yaw_03",
+    "dof_right_knee_04",
+    "dof_right_ankle_02",
+    "dof_left_hip_pitch_04",
+    "dof_left_hip_roll_03",
+    "dof_left_hip_yaw_03",
+    "dof_left_knee_04",
+    "dof_left_ankle_02",
+]

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/__init__.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import gymnasium as gym
+
+from . import agents
+
+##
+# Register Gym environments.
+##
+gym.register(
+    id="Isaac-Tracking-LocoManip-KBot-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+    "env_cfg_entry_point": f"{__name__}.loco_manip_env_cfg:KBotLocoManipEnvCfg",
+    "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:KBotLocoManipPPORunnerCfg",
+    },
+)
+
+
+gym.register(
+    id="Isaac-Tracking-LocoManip-KBot-Play-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+    "env_cfg_entry_point": f"{__name__}.loco_manip_env_cfg:KBotLocoManipEnvCfg_PLAY",
+    "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:KBotLocoManipPPORunnerCfg",
+    },
+)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/__init__.py
@@ -30,3 +30,13 @@ gym.register(
     "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:KBotLocoManipPPORunnerCfg",
     },
 )
+
+gym.register(
+    id="Isaac-Tracking-LocoManip-KBot-RNN-v0",
+    entry_point="isaaclab.envs:ManagerBasedRLEnv",
+    disable_env_checker=True,
+    kwargs={
+        "env_cfg_entry_point": f"{__name__}.rough_rnn_env_cfg:KBotLocoManipEnvCfg",
+        "rsl_rl_cfg_entry_point": f"{agents.__name__}.rsl_rl_ppo_cfg:KBotFlatRNNPPORunnerCfg",
+    },
+)

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/agents/__init__.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/agents/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/agents/rsl_rl_ppo_cfg.py
@@ -1,31 +1,33 @@
-# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
-# All rights reserved.
-#
-# SPDX-License-Identifier: BSD-3-Clause
+"""RSL RL PPO config for kbot."""
 
 from isaaclab.utils import configclass
 
-from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
+from isaaclab_rl.rsl_rl import (
+    RslRlOnPolicyRunnerCfg,
+    RslRlPpoActorCriticCfg,
+    RslRlPpoAlgorithmCfg,
+    RslRlPpoActorCriticRecurrentCfg,
+)
 
 
 @configclass
-class KBotLocoManipPPORunnerCfg(RslRlOnPolicyRunnerCfg):
+class KBotRoughPPORunnerCfg(RslRlOnPolicyRunnerCfg):
     num_steps_per_env = 24
-    max_iterations = 2000
+    max_iterations = 3000000
     save_interval = 50
-    experiment_name = "kbot_loco_manip"
+    experiment_name = "kbot_rough"
     empirical_normalization = False
     policy = RslRlPpoActorCriticCfg(
         init_noise_std=1.0,
-        actor_hidden_dims=[256, 128, 128],
-        critic_hidden_dims=[256, 128, 128],
+        actor_hidden_dims=[512, 256, 128],
+        critic_hidden_dims=[512, 256, 128],
         activation="elu",
     )
     algorithm = RslRlPpoAlgorithmCfg(
         value_loss_coef=1.0,
         use_clipped_value_loss=True,
         clip_param=0.2,
-        entropy_coef=0.01,
+        entropy_coef=0.008,
         num_learning_epochs=5,
         num_mini_batches=4,
         learning_rate=1.0e-3,
@@ -35,3 +37,88 @@ class KBotLocoManipPPORunnerCfg(RslRlOnPolicyRunnerCfg):
         desired_kl=0.01,
         max_grad_norm=1.0,
     )
+
+
+@configclass
+class KBotFlatPPORunnerCfg(KBotRoughPPORunnerCfg):
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.max_iterations = 1500
+        self.experiment_name = "kbot_flat"
+        self.policy.actor_hidden_dims = [256, 128, 128]
+        self.policy.critic_hidden_dims = [256, 128, 128]
+
+@configclass
+class KBotRoughRNNPPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    num_steps_per_env = 24
+    max_iterations = 3000000
+    save_interval = 50
+    experiment_name = "kbot_rough_rnn"
+    empirical_normalization = False
+    policy = RslRlPpoActorCriticRecurrentCfg(
+        init_noise_std=1.0,
+        actor_hidden_dims=[256],
+        critic_hidden_dims=[256],
+        activation="elu",
+        rnn_type="gru",
+        rnn_hidden_dim=512,
+        rnn_num_layers=2,
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.008,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )
+
+@configclass
+class KBotRoughLSTMPPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    num_steps_per_env = 24
+    max_iterations = 300000
+    save_interval = 50
+    experiment_name = "kbot_rough_lstm"
+    empirical_normalization = False
+    policy = RslRlPpoActorCriticRecurrentCfg(
+        init_noise_std=1.0,
+        actor_hidden_dims=[256],
+        critic_hidden_dims=[256],
+        activation="elu",
+        rnn_type="lstm",
+        rnn_hidden_dim=512,
+        rnn_num_layers=2,
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.008,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )
+
+@configclass
+class KBotFlatRNNPPORunnerCfg(KBotRoughPPORunnerCfg):
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.max_iterations = 1500
+        self.experiment_name = "kbot_flat_rnn"
+        self.policy.rnn_type = "gru"
+        self.policy.rnn_hidden_dim = 512
+        self.policy.rnn_num_layers = 2
+

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/agents/rsl_rl_ppo_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/agents/rsl_rl_ppo_cfg.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+from isaaclab.utils import configclass
+
+from isaaclab_rl.rsl_rl import RslRlOnPolicyRunnerCfg, RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
+
+
+@configclass
+class KBotLocoManipPPORunnerCfg(RslRlOnPolicyRunnerCfg):
+    num_steps_per_env = 24
+    max_iterations = 2000
+    save_interval = 50
+    experiment_name = "kbot_loco_manip"
+    empirical_normalization = False
+    policy = RslRlPpoActorCriticCfg(
+        init_noise_std=1.0,
+        actor_hidden_dims=[256, 128, 128],
+        critic_hidden_dims=[256, 128, 128],
+        activation="elu",
+    )
+    algorithm = RslRlPpoAlgorithmCfg(
+        value_loss_coef=1.0,
+        use_clipped_value_loss=True,
+        clip_param=0.2,
+        entropy_coef=0.01,
+        num_learning_epochs=5,
+        num_mini_batches=4,
+        learning_rate=1.0e-3,
+        schedule="adaptive",
+        gamma=0.99,
+        lam=0.95,
+        desired_kl=0.01,
+        max_grad_norm=1.0,
+    )

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/loco_manip_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/loco_manip_env_cfg.py
@@ -29,7 +29,7 @@ class KBotLocoManipRewards(KBotRewards):
     joint_vel_hip_yaw = RewTerm(
         func=mdp.joint_vel_l2,
         weight=-0.001,
-        params={"asset_cfg": SceneEntityCfg("robot", joint_names=[".*_leg_hip_yaw"])},
+        params={"asset_cfg": SceneEntityCfg("robot", joint_names=[".*_hip_yaw.*"])},
     )
 
     left_ee_pos_tracking = RewTerm(

--- a/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/loco_manip_env_cfg.py
+++ b/source/isaaclab_tasks/isaaclab_tasks/manager_based/loco_manipulation/tracking/config/kbot/loco_manip_env_cfg.py
@@ -1,0 +1,257 @@
+# Copyright (c) 2022-2025, The Isaac Lab Project Developers (https://github.com/isaac-sim/IsaacLab/blob/main/CONTRIBUTORS.md).
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+import math
+
+from isaaclab_assets.robots.kscale import ARM_JOINT_NAMES, LEG_JOINT_NAMES
+from isaaclab.managers import EventTermCfg
+from isaaclab.managers import ObservationGroupCfg as ObsGroup
+from isaaclab.managers import ObservationTermCfg as ObsTerm
+from isaaclab.managers import RewardTermCfg as RewTerm
+from isaaclab.managers import SceneEntityCfg
+from isaaclab.utils import configclass
+from isaaclab.utils.noise import AdditiveUniformNoiseCfg as Unoise
+
+import isaaclab_tasks.manager_based.locomotion.velocity.mdp as mdp
+import isaaclab_tasks.manager_based.manipulation.reach.mdp as manipulation_mdp
+from isaaclab_tasks.manager_based.locomotion.velocity.config.kbot.rough_env_cfg import KBotRewards, KBotRoughEnvCfg
+from isaaclab_tasks.manager_based.locomotion.velocity.velocity_env_cfg import EventCfg
+
+LEFT_WRIST_NAME = "KB_C_501X_Left_Bayonet_Adapter_Hard_Stop"
+RIGHT_WRIST_NAME = "KB_C_501X_Right_Bayonet_Adapter_Hard_Stop"
+
+@configclass
+class KBotLocoManipRewards(KBotRewards):
+    joint_deviation_arms = None
+
+    joint_vel_hip_yaw = RewTerm(
+        func=mdp.joint_vel_l2,
+        weight=-0.001,
+        params={"asset_cfg": SceneEntityCfg("robot", joint_names=[".*_leg_hip_yaw"])},
+    )
+
+    left_ee_pos_tracking = RewTerm(
+        func=manipulation_mdp.position_command_error,
+        weight=-2.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=LEFT_WRIST_NAME),
+            "command_name": "left_ee_pose",
+        },
+    )
+
+    left_ee_pos_tracking_fine_grained = RewTerm(
+        func=manipulation_mdp.position_command_error_tanh,
+        weight=2.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=LEFT_WRIST_NAME),
+            "std": 0.05,
+            "command_name": "left_ee_pose",
+        },
+    )
+
+    left_end_effector_orientation_tracking = RewTerm(
+        func=manipulation_mdp.orientation_command_error,
+        weight=-0.2,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=LEFT_WRIST_NAME),
+            "command_name": "left_ee_pose",
+        },
+    )
+
+    right_ee_pos_tracking = RewTerm(
+        func=manipulation_mdp.position_command_error,
+        weight=-2.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=RIGHT_WRIST_NAME),
+            "command_name": "right_ee_pose",
+        },
+    )
+
+    right_ee_pos_tracking_fine_grained = RewTerm(
+        func=manipulation_mdp.position_command_error_tanh,
+        weight=2.0,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=RIGHT_WRIST_NAME),
+            "std": 0.05,
+            "command_name": "right_ee_pose",
+        },
+    )
+
+    right_end_effector_orientation_tracking = RewTerm(
+        func=manipulation_mdp.orientation_command_error,
+        weight=-0.2,
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=RIGHT_WRIST_NAME),
+            "command_name": "right_ee_pose",
+        },
+    )
+
+
+@configclass
+class KBotLocoManipObservations:
+
+    @configclass
+    class PolicyCfg(ObsGroup):
+        base_lin_vel = ObsTerm(
+            func=mdp.base_lin_vel,
+            noise=Unoise(n_min=-0.1, n_max=0.1),
+        )
+        base_ang_vel = ObsTerm(
+            func=mdp.base_ang_vel,
+            noise=Unoise(n_min=-0.2, n_max=0.2),
+        )
+        projected_gravity = ObsTerm(
+            func=mdp.projected_gravity,
+            noise=Unoise(n_min=-0.05, n_max=0.05),
+        )
+        velocity_commands = ObsTerm(
+            func=mdp.generated_commands,
+            params={"command_name": "base_velocity"},
+        )
+        left_ee_pose_command = ObsTerm(
+            func=mdp.generated_commands,
+            params={"command_name": "left_ee_pose"},
+        )
+        right_ee_pose_command = ObsTerm(
+            func=mdp.generated_commands,
+            params={"command_name": "right_ee_pose"},
+        )
+        joint_pos = ObsTerm(
+            func=mdp.joint_pos_rel,
+            # TODO: Confirm LEG_JOINT_NAMES + ARM_JOINT_NAMES match KBot joint naming.
+            params={"asset_cfg": SceneEntityCfg("robot", joint_names=LEG_JOINT_NAMES + ARM_JOINT_NAMES)},
+            noise=Unoise(n_min=-0.01, n_max=0.01),
+        )
+        joint_vel = ObsTerm(
+            func=mdp.joint_vel_rel,
+            # TODO: Confirm LEG_JOINT_NAMES + ARM_JOINT_NAMES match KBot joint naming.
+            params={"asset_cfg": SceneEntityCfg("robot", joint_names=LEG_JOINT_NAMES + ARM_JOINT_NAMES)},
+            noise=Unoise(n_min=-1.5, n_max=1.5),
+        )
+        actions = ObsTerm(func=mdp.last_action)
+
+        def __post_init__(self):
+            self.enable_corruption = True
+            self.concatenate_terms = True
+
+    policy = PolicyCfg()
+
+
+@configclass
+class KBotLocoManipCommands:
+    base_velocity = mdp.UniformVelocityCommandCfg(
+        asset_name="robot",
+        resampling_time_range=(10.0, 10.0),
+        rel_standing_envs=0.25,
+        rel_heading_envs=1.0,
+        heading_command=True,
+        debug_vis=True,
+        ranges=mdp.UniformVelocityCommandCfg.Ranges(
+            lin_vel_x=(-1.0, 1.0),
+            lin_vel_y=(-1.0, 1.0),
+            ang_vel_z=(-1.0, 1.0),
+            heading=(-math.pi, math.pi),
+        ),
+    )
+
+    left_ee_pose = mdp.UniformPoseCommandCfg(
+        asset_name="robot",
+    # TODO: Verify this body exists on KBot asset.
+    body_name=LEFT_WRIST_NAME,
+        resampling_time_range=(1.0, 3.0),
+        debug_vis=True,
+        ranges=mdp.UniformPoseCommandCfg.Ranges(
+            pos_x=(0.10, 0.50),
+            pos_y=(0.05, 0.50),
+            pos_z=(-0.20, 0.20),
+            roll=(-0.1, 0.1),
+            pitch=(-0.1, 0.1),
+            yaw=(math.pi / 2.0 - 0.1, math.pi / 2.0 + 0.1),
+        ),
+    )
+
+    right_ee_pose = mdp.UniformPoseCommandCfg(
+        asset_name="robot",
+    # TODO: Verify this body exists on KBot asset.
+    body_name=RIGHT_WRIST_NAME,
+        resampling_time_range=(1.0, 3.0),
+        debug_vis=True,
+        ranges=mdp.UniformPoseCommandCfg.Ranges(
+            pos_x=(0.10, 0.50),
+            pos_y=(-0.50, -0.05),
+            pos_z=(-0.20, 0.20),
+            roll=(-0.1, 0.1),
+            pitch=(-0.1, 0.1),
+            yaw=(-math.pi / 2.0 - 0.1, -math.pi / 2.0 + 0.1),
+        ),
+    )
+
+
+@configclass
+class KBotEvents(EventCfg):
+    # Add an external force to simulate a payload being carried.
+    left_hand_force = EventTermCfg(
+        func=mdp.apply_external_force_torque,
+        mode="interval",
+        interval_range_s=(10.0, 15.0),
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=LEFT_WRIST_NAME),
+            "force_range": (-10.0, 10.0),
+            "torque_range": (-1.0, 1.0),
+        },
+    )
+
+    right_hand_force = EventTermCfg(
+        func=mdp.apply_external_force_torque,
+        mode="interval",
+        interval_range_s=(10.0, 15.0),
+        params={
+            "asset_cfg": SceneEntityCfg("robot", body_names=RIGHT_WRIST_NAME),
+            "force_range": (-10.0, 10.0),
+            "torque_range": (-1.0, 1.0),
+        },
+    )
+
+
+@configclass
+class KBotLocoManipEnvCfg(KBotRoughEnvCfg):
+    rewards: KBotLocoManipRewards = KBotLocoManipRewards()
+    observations: KBotLocoManipObservations = KBotLocoManipObservations()
+    commands: KBotLocoManipCommands = KBotLocoManipCommands()
+    def __post_init__(self):
+        super().__post_init__()
+
+        self.episode_length_s = 14.0
+
+        # Rewards:
+        self.rewards.flat_orientation_l2.weight = -10.5
+        self.rewards.termination_penalty.weight = -100.0
+
+        # Change terrain to flat.
+        self.scene.terrain.terrain_type = "plane"
+        self.scene.terrain.terrain_generator = None
+        # Remove height scanner. (type ignored to match Digit behaviour)
+        self.scene.height_scanner = None  # type: ignore[assignment]
+        # Remove terrain curriculum.
+        # Note: KBot curriculum uses `terrain_levels`. Setting to None disables
+        # terrain curriculum for this task.
+        self.curriculum.terrain_levels = None  # type: ignore[assignment]
+
+
+@configclass
+class KBotLocoManipEnvCfg_PLAY(KBotLocoManipEnvCfg):
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+
+        # Make a smaller scene for play.
+        self.scene.num_envs = 50
+        self.scene.env_spacing = 2.5
+        # Disable randomization for play.
+        self.observations.policy.enable_corruption = False
+        # Remove random pushing.
+        # KBot uses `events` for random pushes in the rough env config.
+        self.events.base_external_force_torque = None  # type: ignore[assignment]
+        self.events.push_robot = None  # type: ignore[assignment]


### PR DESCRIPTION
Creates a copy of the example locomanipulation environment and replaces all the config for the Digit robot with KBot.

TODO:
- Get rid of more of the locomotion rewards so it just stands still, to focus more on the arm control
- Set it up with the RNN architecture that's been working for locomotion
- Export weights to kinfer and validate sim2sim and sim2real